### PR TITLE
hasColdStartNotification interface on WUP

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -4,7 +4,7 @@
     xmlns:amazon="http://schemas.android.com/apk/lib/com.amazon.device.ads"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     id="phonegap-plugin-push"
-    version="1.3.0.6wr">
+    version="1.3.0.7wr">
 
   <name>PushPlugin</name>
 	<author>Bob Easterday</author>

--- a/src/windows/PushPluginProxy.js
+++ b/src/windows/PushPluginProxy.js
@@ -71,6 +71,9 @@ module.exports = {
             onFail(ex);
         }
     },
+    hasColdStartNotification: function (onSuccess, onFail, args) {
+        onSuccess(false); /* to be done */
+    },
     unregister: function (onSuccess, onFail, args) {
         try {
             myApp.channel.removeEventListener("pushnotificationreceived", myApp.notificationEvent);


### PR DESCRIPTION
The method hasColdStartNotification has been added also for WUP in order to avoid runtime errors. At the moment it always returns false.